### PR TITLE
Enable vaapi video filter setup for GLX mode.

### DIFF
--- a/video.c
+++ b/video.c
@@ -12541,7 +12541,7 @@ int VideoIsDriverVdpau(void)
 int VideoIsDriverVaapi(void)
 {
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule) {
+    if (VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) {
 	return 1;
     }
 #endif
@@ -12639,7 +12639,7 @@ void VideoSetBrightness(int brightness)
 #endif
 
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule && VaapiDecoders[0]->vpp_brightness_idx >= 0) {
+    if ((VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) && VaapiDecoders[0]->vpp_brightness_idx >= 0) {
 	VaapiVideoSetColorbalance(VaapiDecoders[0]->vpp_cbal_buf, VaapiDecoders[0]->vpp_brightness_idx,
 				  VideoConfigClamp(&VaapiConfigBrightness, brightness) *
 				  VaapiConfigBrightness.scale);
@@ -12661,7 +12661,7 @@ int VideoGetBrightnessConfig(int *minvalue, int *defvalue, int *maxvalue)
     }
 #endif
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule) {
+    if (VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) {
 	*minvalue = VaapiConfigBrightness.min_value;
 	*defvalue = VaapiConfigBrightness.def_value;
 	*maxvalue = VaapiConfigBrightness.max_value;
@@ -12686,7 +12686,7 @@ void VideoSetContrast(int contrast)
     }
 #endif
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule && VaapiDecoders[0]->vpp_contrast_idx >= 0) {
+    if ((VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) && VaapiDecoders[0]->vpp_contrast_idx >= 0) {
 	VaapiVideoSetColorbalance(VaapiDecoders[0]->vpp_cbal_buf, VaapiDecoders[0]->vpp_contrast_idx,
 				  VideoConfigClamp(&VaapiConfigContrast, contrast) *
 				  VaapiConfigContrast.scale);
@@ -12708,7 +12708,7 @@ int VideoGetContrastConfig(int *minvalue, int *defvalue, int *maxvalue)
     }
 #endif
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule) {
+    if (VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) {
 	*minvalue = VaapiConfigContrast.min_value;
 	*defvalue = VaapiConfigContrast.def_value;
 	*maxvalue = VaapiConfigContrast.max_value;
@@ -12733,7 +12733,7 @@ void VideoSetSaturation(int saturation)
     }
 #endif
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule && VaapiDecoders[0]->vpp_saturation_idx >= 0) {
+    if ((VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) && VaapiDecoders[0]->vpp_saturation_idx >= 0) {
 	VaapiVideoSetColorbalance(VaapiDecoders[0]->vpp_cbal_buf, VaapiDecoders[0]->vpp_saturation_idx,
 				  VideoConfigClamp(&VaapiConfigSaturation, saturation) *
 				  VaapiConfigSaturation.scale);
@@ -12755,7 +12755,7 @@ int VideoGetSaturationConfig(int *minvalue, int *defvalue, int *maxvalue)
     }
 #endif
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule) {
+    if (VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) {
 	*minvalue = VaapiConfigSaturation.min_value;
 	*defvalue = VaapiConfigSaturation.def_value;
 	*maxvalue = VaapiConfigSaturation.max_value;
@@ -12781,7 +12781,7 @@ void VideoSetHue(int hue)
     }
 #endif
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule && VaapiDecoders[0]->vpp_hue_idx >= 0) {
+    if ((VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) && VaapiDecoders[0]->vpp_hue_idx >= 0) {
 	VaapiVideoSetColorbalance(VaapiDecoders[0]->vpp_cbal_buf, VaapiDecoders[0]->vpp_hue_idx,
 				  VideoConfigClamp(&VaapiConfigHue, hue) * VaapiConfigHue.scale);
     }
@@ -12802,7 +12802,7 @@ int VideoGetHueConfig(int *minvalue, int *defvalue, int *maxvalue)
     }
 #endif
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule) {
+    if (VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) {
 	*minvalue = VaapiConfigHue.min_value;
 	*defvalue = VaapiConfigHue.def_value;
 	*maxvalue = VaapiConfigHue.max_value;
@@ -13059,7 +13059,7 @@ int VideoGetScalingModes(const char* **long_table, const char* **short_table)
     }
 #endif
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule) {
+    if (VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) {
 	*long_table = vaapi_scaling;
 	*short_table = vaapi_scaling_short;
 	return ARRAY_ELEMS(vaapi_scaling);
@@ -13113,7 +13113,7 @@ int VideoGetDeinterlaceModes(const char* **long_table, const char* **short_table
     }
 #endif
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule) {
+    if (VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) {
 	unsigned int len = VaapiDecoders[0]->MaxSupportedDeinterlacer;
 	*long_table = vaapi_deinterlace;
 	*short_table = vaapi_deinterlace_short;
@@ -13131,7 +13131,7 @@ int VideoGetDeinterlaceModes(const char* **long_table, const char* **short_table
 void VideoSetDeinterlace(int mode[VideoResolutionMax])
 {
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule) {
+    if (VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) {
 	int i;
 	for (i = 0; i < VideoResolutionMax; ++i) {
             if (mode[i] > (int)VaapiDecoders[0]->MaxSupportedDeinterlacer)
@@ -13184,7 +13184,7 @@ void VideoSetDenoise(int level[VideoResolutionMax])
     }
 #endif
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule) {
+    if (VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) {
 	int i;
 	for (i = 0; i < VideoResolutionMax; ++i) {
 	    level[i] = VideoConfigClamp(&VaapiConfigDenoise, level[i]);
@@ -13212,7 +13212,7 @@ int VideoGetDenoiseConfig(int *minvalue, int *defvalue, int *maxvalue)
     }
 #endif
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule) {
+    if (VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) {
         *minvalue = VaapiConfigDenoise.min_value;
         *defvalue = VaapiConfigDenoise.def_value;
         *maxvalue = VaapiConfigDenoise.max_value;
@@ -13236,7 +13236,7 @@ void VideoSetSharpen(int level[VideoResolutionMax])
     }
 #endif
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule) {
+    if (VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) {
 	int i;
 	for (i = 0; i < VideoResolutionMax; ++i) {
 	    level[i] = VideoConfigClamp(&VaapiConfigSharpen, level[i]);
@@ -13264,7 +13264,7 @@ int VideoGetSharpenConfig(int *minvalue, int *defvalue, int *maxvalue)
     }
 #endif
 #ifdef USE_VAAPI
-    if (VideoUsedModule == &VaapiModule) {
+    if (VideoUsedModule == &VaapiModule || VideoUsedModule == &VaapiGlxModule) {
         *minvalue = VaapiConfigSharpen.min_value;
         *defvalue = VaapiConfigSharpen.def_value;
         *maxvalue = VaapiConfigSharpen.max_value;


### PR DESCRIPTION
Fixes non-existent menus and crash-boom-bangs.