### PR TITLE
Fix memory leak

### DIFF
--- a/video.c
+++ b/video.c
@@ -3132,6 +3132,7 @@ static VAStatus VaapiPostprocessSurface(VAContextID ctx,
         return va_status;
     }
     vaEndPicture(VaDisplay, ctx);
+    vaDestroyBuffer(VaDisplay, pipeline_buf);
     return VA_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
https://01org.github.io/libva/group__api__core.html#gaba254978bf0d32781f4a9e67f1fa7a78
"The user must call vaDestroyBuffer() to destroy a buffer."

https://www.vdr-portal.de/forum/index.php?thread/126111-etwas-frist-speicher-vdr-streamdev-softhddevice-ffmpeg-vdpau-vdr/&postID=1298217#post1298217